### PR TITLE
Fix ProtectedDownload auth bool and callback

### DIFF
--- a/src/components/ProtectedDownload.jsx
+++ b/src/components/ProtectedDownload.jsx
@@ -27,7 +27,8 @@ export default function ProtectedDownload({
         sessionStorage.removeItem("hydra_download_timestamp");
         setIsAuthenticated(false);
       } else {
-        setIsAuthenticated(isAuth && token);
+        // Aseguramos valor booleano para evitar estados inconsistentes
+        setIsAuthenticated(isAuth && Boolean(token));
       }
     };
 
@@ -70,6 +71,11 @@ export default function ProtectedDownload({
         detail: { downloadUrl },
       });
       window.dispatchEvent(event);
+
+      // Notificar al callback si fue provisto
+      if (typeof onAuthRequired === "function") {
+        onAuthRequired();
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- correct boolean handling in ProtectedDownload authentication
- invoke optional onAuthRequired callback when auth is needed

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685065986c5883279c37f176b004f65a